### PR TITLE
Add `fhtml`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -317,6 +317,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "fhtml"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c91523ba403fb620827fbc01cc532af6c6cc42c211d7da0224f1abc906c103"
+dependencies = [
+ "fhtml-macros",
+]
+
+[[package]]
+name = "fhtml-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3cc42d47d802b9ee0f29e7323b6dcabb724d5ccc9b8469c697c820ad533e00"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -969,6 +989,7 @@ version = "0.1.0"
 dependencies = [
  "askama",
  "divan",
+ "fhtml",
  "handlebars",
  "html-node",
  "hyped",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ serde_json = "1.0.111"
 minijinja = "1.0.10"
 html-node = "0.5.0"
 hypertext = "0.3.0"
+fhtml = "0.4.1"
 
 [[bench]]
 name = "hyped"
@@ -52,4 +53,8 @@ harness = false
 
 [[bench]]
 name = "hypertext"
+harness = false
+
+[[bench]]
+name = "fhtml"
 harness = false

--- a/benches/fhtml.rs
+++ b/benches/fhtml.rs
@@ -1,0 +1,108 @@
+use std::fmt::Write;
+
+fn main() {
+    divan::main()
+}
+
+const SIZE: usize = 100;
+
+#[divan::bench]
+fn big_table(bencher: divan::Bencher) {
+    let mut table = Vec::with_capacity(SIZE);
+    for _ in 0..SIZE {
+        let mut inner = Vec::with_capacity(SIZE);
+        for i in 0..SIZE {
+            inner.push(i);
+        }
+        table.push(inner);
+    }
+
+    bencher.bench(|| big_table_render(&table))
+}
+
+fn big_table_render(rows: &Vec<Vec<usize>>) -> String {
+    let page = fhtml::format! {
+        <table>
+            {
+                rows.iter().fold(String::new(), |mut f, cols| {
+                    let _ = fhtml::write! { f,
+                        <tr>
+                            {
+                                cols.iter().fold(String::new(), |mut f, col| {
+                                    let _ = fhtml::write! { f,
+                                        <td>{col}</td>
+                                    };
+                                    f
+                                })
+                            }
+                        </tr>
+                    };
+                    f
+                })
+            }
+        </table>
+    };
+    page.to_string()
+}
+
+#[divan::bench]
+fn teams(bencher: divan::Bencher) {
+    let teams = Teams {
+        year: 2015,
+        teams: vec![
+            Team {
+                name: "Jiangsu".into(),
+                score: 43,
+            },
+            Team {
+                name: "Beijing".into(),
+                score: 27,
+            },
+            Team {
+                name: "Guangzhou".into(),
+                score: 22,
+            },
+            Team {
+                name: "Shandong".into(),
+                score: 12,
+            },
+        ],
+    };
+
+    bencher.bench(|| teams_render(&teams))
+}
+
+fn teams_render(teams: &Teams) -> String {
+    fhtml::format! {
+        <html>
+            <head>
+                <title>{teams.year}</title>
+            </head>
+            <body>
+                <h1>"CSL " {teams.year}</h1>
+                <ul>
+                    {
+                        teams.teams.iter().enumerate().fold(String::new(), |mut f, (idx, team)| {
+                            let _ = fhtml::write! { f,
+                                <li class={if idx == 0 { "champion" } else { "" }}>
+                                    <b>{team.name}</b> ": " {team.score}
+                                </li>
+                            };
+                            f
+                        })
+                    }
+                </ul>
+            </body>
+        </html>
+    }
+}
+
+struct Teams {
+    year: u16,
+    teams: Vec<Team>,
+}
+
+struct Team {
+    name: String,
+    score: u8,
+}


### PR DESCRIPTION
I've made a rust HTML library that uses formatting macros w-o custom traits, instead of string pushing w custom traits, sacrificing a bit of performance for simplicity and flexibility, I thought it could be interesting to add it here.